### PR TITLE
8 redirecturi are defined in mercadolibreapi but throws an error when use getauthenticationurl

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ pnpm*
 node_modules
 prettier*
 jest.config.js
+tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] - 2023-10-15
+
+### Fixed
+
+* redirectUri are defined in MercadoLibreAPI but throws an error when use getAuthenticationUrl [#8](https://github.com/TheBeSharpsDevs/meli-node-sdk-unnoficial/issues/8)
+* tsconfig error when install meli-node-sdk-unnoficial
+
+### Added
+
+* Support for import default MercadoLibreAPI and naming import other modules
+
 ## [0.0.3] - 2023-10-14
 
 ### Added
-- Add Authentication URL retriever with configuration params.
-- New CHANGELOG file based https://keepachangelog.com/en/1.0.0/
-- Add testing for new features.
+* Add Authentication URL retriever with configuration params.
+* New CHANGELOG file based https://keepachangelog.com/en/1.0.0/
+* Add testing for new features.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint-config-prettier": "9.0.0",
         "eslint-config-standard-with-typescript": "39.1.1",
         "eslint-plugin-import": "2.28.1",
-        "eslint-plugin-n": "15.0.0 || 16.0.0 ",
+        "eslint-plugin-n": "16.0.0",
         "eslint-plugin-prettier": "5.0.1",
         "eslint-plugin-promise": "6.1.1",
         "husky": "8.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meli-node-sdk-unnoficial",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A Mercadolibre NodeJS SDK with the goal of be the most updated SKD available for NodeJS",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-config-prettier": "9.0.0",
     "eslint-config-standard-with-typescript": "39.1.1",
     "eslint-plugin-import": "2.28.1",
-    "eslint-plugin-n": "15.0.0 || 16.0.0 ",
+    "eslint-plugin-n": "16.0.0",
     "eslint-plugin-prettier": "5.0.1",
     "eslint-plugin-promise": "6.1.1",
     "husky": "8.0.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "format": "prettier --write .",
     "build": "tsc",
     "prepare": "npm run build",
-    "test": "jest --no-cache --runInBand --detectOpenHandles --passWithNoTests"
+    "test": "jest --no-cache --runInBand --detectOpenHandles --passWithNoTests",
+    "test:watch": "jest --no-cache --runInBand --detectOpenHandles --passWithNoTests --watch"
   },
   "types": "dist/index.d.ts",
   "dependencies": {

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -46,16 +46,19 @@ export class MercadolibreAPIAuth implements IMercadolibreAPIAuth {
       countries.find((country) => country.domain_url == config?.domain) ?? null;
     this.request = request ?? createAxios(config?.domain);
 
-    if (!this.clientId || !this.clientSecret || !this.redirectUri) {
+    if (!this.clientId || !this.clientSecret) {
       throw new MeliValidationError(
-        "Params clientId, clientSecret and redirectUri are required within configuration or environment scope.",
+        "Params clientId, clientSecret are required within configuration or environment scope.",
       );
     }
   }
 
-  async getAuthenticationUrl(params: AuthenticationParams): Promise<string> {
-    if (!params?.redirectUri || !this.redirectUri) {
-      throw new Error("redirectUri is required");
+  async getAuthenticationUrl(params?: AuthenticationParams): Promise<string> {
+    console.log(!params?.redirectUri && !this.redirectUri);
+    if (!params?.redirectUri && !this.redirectUri) {
+      throw new Error(
+        "redirectUri is required in configuration or environment",
+      );
     }
     const authenticationUrl = new URL(
       `https://auth.mercadolibre.${
@@ -68,7 +71,7 @@ export class MercadolibreAPIAuth implements IMercadolibreAPIAuth {
       params?.redirectUri ?? this.redirectUri,
     );
     authenticationUrl.searchParams.append("client_id", this.clientId);
-    if (params.pkce) {
+    if (params?.pkce) {
       authenticationUrl.searchParams.append(
         "code_challenge",
         params.codeChallenge,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,9 @@ export class MercadolibreAPI {
     }
   }
 }
+
+export * from './auth/auth';
+export * from './base';
+export * from './countries';
+export * from './errors';
+export default MercadolibreAPI


### PR DESCRIPTION
# Summary version 0.0.4

### Fixed

* redirectUri are defined in MercadoLibreAPI but throws an error when use getAuthenticationUrl [#8](https://github.com/TheBeSharpsDevs/meli-node-sdk-unnoficial/issues/8)
* tsconfig error when install meli-node-sdk-unnoficial

### Added

* Support for import default MercadoLibreAPI and naming import other modules
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

