### PR TITLE
feat: :sparkles: Add refreshAccessToken method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6] - 2023-10-15
+
+### Added
+
+* `refreshAccessToken` method on `auth` module.
+* testing cases for `refreshAccessToken`
+
 ## [0.0.5] - 2023-10-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meli-node-sdk-unnoficial",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A Mercadolibre NodeJS SDK with the goal of be the most updated SKD available for NodeJS",
   "main": "dist/index.js",
   "scripts": {

--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -110,4 +110,37 @@ export class MercadolibreAPIAuth implements IMercadolibreAPIAuth {
     const token = axiosResponse.data;
     return token;
   }
+
+  async refreshAccessToken(
+    refreshToken: string,
+  ): Promise<IAccessTokenResponse> {
+    if (!refreshToken && !this.refreshToken) {
+      throw new Error("refreshToken is required");
+    }
+    const axiosResponse = await this.client
+      .post(EXCHANGE_TOKEN_PATH, null, {
+        params: {
+          grant_type: GrantTypeEnum.REFRESH_TOKEN,
+          client_id: this.clientId,
+          client_secret: this.clientSecret,
+          refresh_token: refreshToken || this.refreshToken,
+        },
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+      })
+      .catch((error: Error | AxiosError) => {
+        if (error instanceof AxiosError) {
+          throw new MeliError(
+            error.response?.data.error,
+            error.stack,
+            error.response?.status,
+          );
+        }
+        throw error;
+      });
+    const token = axiosResponse.data;
+    return token;
+  }
 }

--- a/src/base.ts
+++ b/src/base.ts
@@ -73,6 +73,7 @@ export interface IMercadolibreErrorResponse {
 export enum GrantTypeEnum {
   CODE = "code",
   AUTHORIZATION_CODE = "authorization_code",
+  REFRESH_TOKEN = "refresh_token",
 }
 
 export interface IMercadolibreAPIAuth {
@@ -82,6 +83,7 @@ export interface IMercadolibreAPIAuth {
     redirectUri?: string,
     codeVerifier?: string,
   ): Promise<IAccessTokenResponse>;
+  refreshAccessToken(refreshToken: string): Promise<IAccessTokenResponse>;
 }
 
 export const DEFAULT_SCOPE = "offline_access read write";


### PR DESCRIPTION
# Summary version v0.0.6

### Added

* `refreshAccessToken` method on `auth` module.
* testing cases for `refreshAccessToken`

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

